### PR TITLE
fix: Use hardcoded dev token for internal API calls

### DIFF
--- a/src/services/domain_to_sitemap_adapter_service.py
+++ b/src/services/domain_to_sitemap_adapter_service.py
@@ -99,14 +99,9 @@ class DomainToSitemapAdapterService:
             }
 
             # 3. Make HTTP POST request
-            api_key = settings.dev_token or "scraper_sky_2024"  # Fallback to dev token
-            if not api_key:
-                logger.error("Adapter Service: dev_token not found in settings.")
-                domain.sitemap_analysis_status = SitemapAnalysisStatusEnum.failed  # type: ignore
-                domain.sitemap_analysis_error = (
-                    "Configuration Error: dev_token missing."  # type: ignore
-                )
-                return False
+            # Use the development bypass token for internal API calls
+            # This token is recognized by jwt_auth.py:95 for development mode bypass
+            api_key = "scraper_sky_2024"
 
             headers = {
                 "Authorization": f"Bearer {api_key}",


### PR DESCRIPTION
Fixes JWT authentication error in domain_to_sitemap_adapter_service

- Replace settings.dev_token with 'scraper_sky_2024' for internal calls
- Fixes JWT 'Not enough segments' error 
- Ensures consistent authentication for internal /api/v3/sitemap/scan calls
- Token is recognized by jwt_auth.py development mode bypass

Reference: Resolves issue reported in PR #3

🤖 Generated with [Claude Code](https://claude.ai/code)